### PR TITLE
feat(cli)!: add profiles, XDG config, and multi-auth system

### DIFF
--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1.4
+
+# deva.sh - Rust Developer Image
+# Extends main deva image with Rust toolchain and ecosystem tools
+
+ARG BASE_IMAGE=ghcr.io/thevibeworks/deva:latest
+FROM ${BASE_IMAGE}
+
+LABEL org.opencontainers.image.title="deva-rust"
+LABEL org.opencontainers.image.description="Rust development environment with full toolchain"
+
+ARG RUST_TOOLCHAINS="stable"
+ARG RUST_TARGETS="wasm32-unknown-unknown"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/cargo \
+    PATH=/opt/cargo/bin:$PATH
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libpq-dev postgresql-client \
+        libmysqlclient-dev mysql-client \
+        libsqlite3-dev sqlite3 \
+        libssl-dev \
+        libcurl4-openssl-dev \
+        libpng-dev libjpeg-dev \
+        libudev-dev \
+        libproc2-dev
+
+RUN --mount=type=cache,target=/tmp/rust-cache,sharing=locked \
+    set -euxo pipefail && \
+    mkdir -p "$RUSTUP_HOME" "$CARGO_HOME" && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain none --profile default && \
+    rustup toolchain install ${RUST_TOOLCHAINS} && \
+    for tc in ${RUST_TOOLCHAINS}; do \
+        rustup component add --toolchain "$tc" rustfmt clippy rust-analyzer; \
+    done && \
+    if [ -n "${RUST_TARGETS}" ]; then \
+        for tc in ${RUST_TOOLCHAINS}; do \
+            rustup target add --toolchain "$tc" ${RUST_TARGETS}; \
+        done; \
+    fi && \
+    rustup default stable
+
+RUN chown -R "$DEVA_UID:$DEVA_GID" "$RUSTUP_HOME" "$CARGO_HOME"
+
+RUN echo 'export PATH="/opt/cargo/bin:$PATH"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'export RUSTUP_HOME=/opt/rustup' >> "$DEVA_HOME/.zshrc" && \
+    echo 'export CARGO_HOME=/opt/cargo' >> "$DEVA_HOME/.zshrc" && \
+    sed -i 's/plugins=(git docker python golang node npm aws/plugins=(git docker python golang rust node npm aws/' "$DEVA_HOME/.zshrc" && \
+    echo '# Rust aliases' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cr="cargo run"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cb="cargo build"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias ct="cargo test"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cc="cargo check"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cw="cargo watch -x check -x test -x run"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cf="cargo fmt"' >> "$DEVA_HOME/.zshrc" && \
+    echo 'alias cl="cargo clippy"' >> "$DEVA_HOME/.zshrc"

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -29,11 +29,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libcurl4-openssl-dev \
         libpng-dev libjpeg-dev \
         libudev-dev \
-        libproc2-dev
+        libproc2-dev \
+        libzmq3-dev libzmq5 libczmq-dev
 
 RUN --mount=type=cache,target=/tmp/rust-cache,sharing=locked \
     set -euxo pipefail && \
     mkdir -p "$RUSTUP_HOME" "$CARGO_HOME" && \
+    mkdir -p "$CARGO_HOME/registry/cache" "$CARGO_HOME/registry/index" "$CARGO_HOME/git" && \
+    chown -R "$DEVA_UID:$DEVA_GID" "$RUSTUP_HOME" "$CARGO_HOME" && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
         sh -s -- -y --default-toolchain none --profile default && \
     rustup toolchain install ${RUST_TOOLCHAINS} && \
@@ -45,9 +48,8 @@ RUN --mount=type=cache,target=/tmp/rust-cache,sharing=locked \
             rustup target add --toolchain "$tc" ${RUST_TARGETS}; \
         done; \
     fi && \
-    rustup default stable
-
-RUN chown -R "$DEVA_UID:$DEVA_GID" "$RUSTUP_HOME" "$CARGO_HOME"
+    rustup default stable && \
+    chown -R "$DEVA_UID:$DEVA_GID" "$RUSTUP_HOME" "$CARGO_HOME"
 
 RUN echo 'export PATH="/opt/cargo/bin:$PATH"' >> "$DEVA_HOME/.zshrc" && \
     echo 'export RUSTUP_HOME=/opt/rustup' >> "$DEVA_HOME/.zshrc" && \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 
 IMAGE_NAME := ghcr.io/thevibeworks/deva
 TAG := latest
+RUST_TAG := rust
+DOCKERFILE := Dockerfile
+RUST_DOCKERFILE := Dockerfile.rust
+MAIN_IMAGE := $(IMAGE_NAME):$(TAG)
+RUST_IMAGE := $(IMAGE_NAME):$(RUST_TAG)
 CONTAINER_NAME := deva-$(shell basename $(PWD))-$(shell date +%s)
-CLAUDE_CODE_VERSION := 1.0.115
-CODEX_VERSION := 0.36.0
+CLAUDE_CODE_VERSION := 1.0.119
+CODEX_VERSION := 0.39.0
 
 export DOCKER_BUILDKIT := 1
 
@@ -11,30 +16,49 @@ export DOCKER_BUILDKIT := 1
 
 .PHONY: build
 build:
-	@echo "🔨 Building deva.sh Docker image..."
-	docker build --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(IMAGE_NAME):$(TAG) .
-	@echo "✅ Build completed: $(IMAGE_NAME):$(TAG)"
+	@echo "🔨 Building Docker image with $(DOCKERFILE)..."
+	docker build -f $(DOCKERFILE) --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(MAIN_IMAGE) .
+	@echo "✅ Build completed: $(MAIN_IMAGE)"
 
 .PHONY: rebuild
 rebuild:
-	@echo "🔨 Rebuilding deva.sh Docker image (no cache)..."
-	docker build --no-cache --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(IMAGE_NAME):$(TAG) .
-	@echo "✅ Rebuild completed: $(IMAGE_NAME):$(TAG)"
+	@echo "🔨 Rebuilding Docker image (no cache) with $(DOCKERFILE)..."
+	docker build -f $(DOCKERFILE) --no-cache --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(MAIN_IMAGE) .
+	@echo "✅ Rebuild completed: $(MAIN_IMAGE)"
+
+
+.PHONY: build-rust
+build-rust:
+	@echo "🔨 Building Rust Docker image..."
+	docker build -f $(RUST_DOCKERFILE) --build-arg BASE_IMAGE=$(MAIN_IMAGE) -t $(RUST_IMAGE) .
+	@echo "✅ Rust build completed: $(RUST_IMAGE)"
+
+.PHONY: build-all
+build-all: build build-rust
+	@echo "✅ All images built successfully"
 
 .PHONY: buildx
 buildx:
 	@echo "🔨 Building with docker buildx..."
-	docker buildx build --load --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(IMAGE_NAME):$(TAG) .
-	@echo "✅ Buildx completed: $(IMAGE_NAME):$(TAG)"
+	docker buildx build -f $(DOCKERFILE) --load --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) --build-arg CODEX_VERSION=$(CODEX_VERSION) -t $(MAIN_IMAGE) .
+	@echo "✅ Buildx completed: $(MAIN_IMAGE)"
 
 .PHONY: buildx-multi
 buildx-multi:
 	@echo "🔨 Building multi-arch images for amd64 and arm64..."
-	docker buildx build --platform linux/amd64,linux/arm64 \
+	docker buildx build -f $(DOCKERFILE) --platform linux/amd64,linux/arm64 \
 		--build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) \
 		--build-arg CODEX_VERSION=$(CODEX_VERSION) \
-		--push -t $(IMAGE_NAME):$(TAG) .
-	@echo "✅ Multi-arch build completed and pushed: $(IMAGE_NAME):$(TAG)"
+		--push -t $(MAIN_IMAGE) .
+	@echo "✅ Multi-arch build completed and pushed: $(MAIN_IMAGE)"
+
+.PHONY: buildx-multi-rust
+buildx-multi-rust:
+	@echo "🔨 Building multi-arch Rust images for amd64 and arm64..."
+	docker buildx build -f $(RUST_DOCKERFILE) --platform linux/amd64,linux/arm64 \
+		--build-arg BASE_IMAGE=$(MAIN_IMAGE) \
+		--push -t $(RUST_IMAGE) .
+	@echo "✅ Multi-arch Rust build completed and pushed: $(RUST_IMAGE)"
 
 .PHONY: buildx-multi-local
 buildx-multi-local:
@@ -42,68 +66,79 @@ buildx-multi-local:
 	docker buildx build --platform linux/amd64,linux/arm64 \
 		--build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) \
 		--build-arg CODEX_VERSION=$(CODEX_VERSION) \
-		-t $(IMAGE_NAME):$(TAG) .
-	@echo "✅ Multi-arch build completed locally: $(IMAGE_NAME):$(TAG)"
+		-t $(MAIN_IMAGE) .
+	@echo "✅ Multi-arch build completed locally: $(MAIN_IMAGE)"
 
 .PHONY: clean
 clean:
 	@echo "🧹 Cleaning up Docker artifacts..."
-	-docker rmi $(IMAGE_NAME):$(TAG) 2>/dev/null || true
+	-docker rmi $(MAIN_IMAGE) 2>/dev/null || true
+	-docker rmi $(RUST_IMAGE) 2>/dev/null || true
 	-docker system prune -f
 	@echo "✅ Cleanup completed"
 
 .PHONY: clean-all
 clean-all:
 	@echo "🧹 Deep cleaning Docker artifacts and build cache..."
-	-docker rmi $(IMAGE_NAME):$(TAG) 2>/dev/null || true
+	-docker rmi $(MAIN_IMAGE) 2>/dev/null || true
+	-docker rmi $(RUST_IMAGE) 2>/dev/null || true
 	-docker builder prune -af
 	-docker system prune -af --volumes
 	@echo "✅ Deep cleanup completed"
 
 .PHONY: shell
 shell:
-	@echo "🐚 Opening shell in $(IMAGE_NAME):$(TAG)..."
+	@echo "🐚 Opening shell in $(MAIN_IMAGE)..."
 	docker run --rm -it \
 		-v $(PWD):$(PWD) \
 		-w $(PWD) \
 		--name $(CONTAINER_NAME) \
-		$(IMAGE_NAME):$(TAG) /bin/zsh
+		$(MAIN_IMAGE) /bin/zsh
 
 .PHONY: test
 test:
-	@echo "🧪 Testing $(IMAGE_NAME):$(TAG)..."
+	@echo "🧪 Testing $(MAIN_IMAGE)..."
 	@echo "Testing claude command..."
-	docker run --rm $(IMAGE_NAME):$(TAG) claude --version
+	docker run --rm $(MAIN_IMAGE) claude --version
 	@echo "Testing development tools..."
-	docker run --rm $(IMAGE_NAME):$(TAG) bash -c 'python --version && node --version && go version && rustc --version'
+	docker run --rm $(MAIN_IMAGE) bash -c 'python --version && node --version && go version'
 	@echo "✅ All tests passed"
+
+.PHONY: test-rust
+test-rust:
+	@echo "🧪 Testing $(RUST_IMAGE)..."
+	@echo "Testing Rust toolchain..."
+	docker run --rm $(RUST_IMAGE) bash -c 'rustc --version && cargo --version && rustfmt --version && clippy-driver --version'
+	@echo "Testing Rust tools..."
+	docker run --rm $(RUST_IMAGE) bash -c 'cargo-watch --version && wasm-pack --version'
+	@echo "✅ Rust tests passed"
 
 .PHONY: test-local
 test-local:
-	@echo "🧪 Testing $(IMAGE_NAME):$(TAG) with local directory..."
+	@echo "🧪 Testing $(MAIN_IMAGE) with local directory..."
 	docker run --rm -it \
 		-v $(PWD):$(PWD) \
 		-w $(PWD) \
-		$(IMAGE_NAME):$(TAG) bash -c 'pwd && ls -la && claude --version'
+		$(MAIN_IMAGE) bash -c 'pwd && ls -la && claude --version'
 
 .PHONY: info
 info:
-	@echo "📊 Image information for $(IMAGE_NAME):$(TAG):"
-	@docker images $(IMAGE_NAME):$(TAG) --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
+	@echo "📊 Image information for $(MAIN_IMAGE):"
+	@docker images $(MAIN_IMAGE) --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedAt}}"
 	@echo ""
 	@echo "🔍 Image layers:"
-	@docker history $(IMAGE_NAME):$(TAG) --no-trunc
+	@docker history $(MAIN_IMAGE) --no-trunc
 
 .PHONY: push
 push:
-	@echo "📤 Pushing $(IMAGE_NAME):$(TAG) to registry..."
-	docker push $(IMAGE_NAME):$(TAG)
+	@echo "📤 Pushing $(MAIN_IMAGE) to registry..."
+	docker push $(MAIN_IMAGE)
 	@echo "✅ Push completed"
 
 .PHONY: pull
 pull:
-	@echo "📥 Pulling $(IMAGE_NAME):$(TAG) from registry..."
-	docker pull $(IMAGE_NAME):$(TAG)
+	@echo "📥 Pulling $(MAIN_IMAGE) from registry..."
+	docker pull $(MAIN_IMAGE)
 	@echo "✅ Pull completed"
 
 .PHONY: build-test
@@ -153,23 +188,35 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Available targets:"
-	@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z_-]+:.*?##/ { printf "  %-15s %s\n", $$1, $$2 } /^##@/ { printf "\n%s\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+	@echo "  build                Build main Docker image"
+	@echo "  build-rust           Build Rust Docker image"
+	@echo "  build-all            Build all images"
+	@echo "  rebuild              Rebuild without cache"
+	@echo "  buildx               Build with buildx"
+	@echo "  buildx-multi         Build multi-arch and push"
+	@echo "  buildx-multi-rust    Build multi-arch Rust and push"
+	@echo "  test                 Test main image"
+	@echo "  test-rust            Test Rust image"
+	@echo "  shell                Open shell in container"
+	@echo "  clean                Clean up Docker artifacts"
+	@echo "  clean-all            Deep clean with build cache"
+	@echo "  push                 Push image to registry"
+	@echo "  pull                 Pull image from registry"
+	@echo "  info                 Show image information"
+	@echo "  lint                 Lint Dockerfile"
 	@echo ""
 	@echo "Environment variables:"
-	@echo "  IMAGE_NAME           Docker image name (default: $(IMAGE_NAME))"
+	@echo "  IMAGE_NAME           Main image name (default: $(IMAGE_NAME))"
 	@echo "  TAG                  Docker image tag (default: $(TAG))"
+	@echo "  RUST_TAG             Rust image tag (default: $(RUST_TAG))"
+	@echo "  DOCKERFILE           Dockerfile to use (default: $(DOCKERFILE))"
+	@echo "  RUST_DOCKERFILE      Rust Dockerfile path (default: $(RUST_DOCKERFILE))"
 	@echo "  CLAUDE_CODE_VERSION  Claude CLI version (default: $(CLAUDE_CODE_VERSION))"
 	@echo "  CODEX_VERSION        Codex CLI version (default: $(CODEX_VERSION))"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make build                                    # Build the image"
-	@echo "  make rebuild                                  # Rebuild without cache"
-	@echo "  make shell                                    # Open shell in container"
-	@echo "  make test                                     # Test image functionality"
-	@echo "  make TAG=dev build                            # Build with custom tag"
-	@echo "  make CLAUDE_CODE_VERSION=1.0.45 build        # Build with specific Claude version"
-	@echo "  make clean                                    # Clean up Docker artifacts"
-	@echo "  make version-check                            # Check version consistency"
-	@echo "  make release-patch                            # Create patch release"
-	@echo "  make release-minor                            # Create minor release"
-	@echo "  make release-major                            # Create major release"
+	@echo "  make build                                    # Build main image"
+	@echo "  make build-rust                               # Build Rust image"
+	@echo "  make DOCKERFILE=$(RUST_DOCKERFILE) build         # Build with specific Dockerfile"
+	@echo "  make TAG=dev build-all                        # Build all with custom tag"
+	@echo "  make CLAUDE_CODE_VERSION=1.0.117 build       # Build with specific Claude version"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ build-rust:
 	@echo "✅ Rust build completed: $(RUST_IMAGE)"
 
 .PHONY: build-all
-build-all: build build-rust
+build-all:
+	@echo "🔨 Building all images with versions: Claude $(CLAUDE_CODE_VERSION), Codex $(CODEX_VERSION)..."
+	@$(MAKE) build CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) CODEX_VERSION=$(CODEX_VERSION)
+	@$(MAKE) build-rust BASE_IMAGE=$(MAIN_IMAGE)
 	@echo "✅ All images built successfully"
 
 .PHONY: buildx

--- a/agents/claude.sh
+++ b/agents/claude.sh
@@ -31,11 +31,22 @@ agent_prepare() {
         using_custom_home=true
     fi
 
-    if [ "$using_custom_home" = false ]; then
+    if [ "$using_custom_home" = false ] && [ -z "${CONFIG_ROOT:-}" ]; then
         if [ -d "$HOME/.claude" ]; then
             DOCKER_ARGS+=("-v" "$HOME/.claude:/home/deva/.claude")
         fi
         if [ -f "$HOME/.claude.json" ]; then
+            DOCKER_ARGS+=("-v" "$HOME/.claude.json:/home/deva/.claude.json")
+        fi
+    fi
+
+    # Back-compat: if CONFIG_HOME was auto-selected and has no Claude creds,
+    # but host creds exist, also mount host creds.
+    if [ "$using_custom_home" = true ] && [ "${CONFIG_HOME_AUTO:-false}" = true ] && [ -z "${CONFIG_ROOT:-}" ]; then
+        if [ ! -d "$CONFIG_HOME/.claude" ] && [ -d "$HOME/.claude" ]; then
+            DOCKER_ARGS+=("-v" "$HOME/.claude:/home/deva/.claude")
+        fi
+        if [ ! -f "$CONFIG_HOME/.claude.json" ] && [ -f "$HOME/.claude.json" ]; then
             DOCKER_ARGS+=("-v" "$HOME/.claude.json:/home/deva/.claude.json")
         fi
     fi

--- a/agents/claude.sh
+++ b/agents/claude.sh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 
+# Load shared auth utilities
+# shellcheck disable=SC1091
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/shared_auth.sh" ]; then
+    source "$(dirname "${BASH_SOURCE[0]}")/shared_auth.sh"
+fi
+
 agent_prepare() {
     local -a args
     if [ $# -gt 0 ]; then
@@ -9,9 +15,15 @@ agent_prepare() {
     fi
     AGENT_COMMAND=("claude")
 
+    # Parse auth method and filter remaining args using shared function
+    parse_auth_args "claude" "${args[@]+"${args[@]}"}"
+    local auth_method="$PARSED_AUTH_METHOD"
+    # Safe array assignment that works with set -u
+    local -a remaining_args=("${PARSED_REMAINING_ARGS[@]+"${PARSED_REMAINING_ARGS[@]}"}")
+
     local has_dangerously=false
-    if [ ${#args[@]} -gt 0 ]; then
-        for arg in "${args[@]}"; do
+    if [ ${#remaining_args[@]} -gt 0 ]; then
+        for arg in "${remaining_args[@]}"; do
             if [ "$arg" = "--dangerously-skip-permissions" ]; then
                 has_dangerously=true
                 break
@@ -22,9 +34,11 @@ agent_prepare() {
         AGENT_COMMAND+=("--dangerously-skip-permissions")
     fi
 
-    if [ ${#args[@]} -gt 0 ]; then
-        AGENT_COMMAND+=("${args[@]}")
-    fi
+    # Safe array expansion for remaining args
+    AGENT_COMMAND+=("${remaining_args[@]+"${remaining_args[@]}"}")
+
+    # Setup authentication
+    setup_claude_auth "$auth_method"
 
     local using_custom_home=false
     if [ -n "${CONFIG_HOME:-}" ]; then
@@ -53,4 +67,84 @@ agent_prepare() {
     if [ -d "$(pwd)/.claude" ]; then
         DOCKER_ARGS+=("-v" "$(pwd)/.claude:$(pwd)/.claude")
     fi
+}
+
+setup_claude_auth() {
+    local method="$1"
+
+    case "$method" in
+        claude)
+            # Default Claude.ai OAuth - handled by existing mount logic
+            ;;
+        api-key)
+            validate_anthropic_key || auth_error "ANTHROPIC_API_KEY not set for --auth-with api-key" \
+                                                  "Set: export ANTHROPIC_API_KEY=your_api_key"
+            DOCKER_ARGS+=("-e" "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY")
+            ;;
+        copilot)
+            validate_github_token || auth_error "No GitHub token found for copilot auth" \
+                                                "Run: copilot-api auth, or set GH_TOKEN=\$(gh auth token)"
+            start_copilot_proxy
+
+            DOCKER_ARGS+=("-e" "ANTHROPIC_BASE_URL=http://$COPILOT_HOST_MAPPING:$COPILOT_PROXY_PORT")
+            DOCKER_ARGS+=("-e" "ANTHROPIC_API_KEY=dummy")
+
+            # Auto-detect models if not already set
+            if [ -z "${ANTHROPIC_MODEL:-}" ] || [ -z "${ANTHROPIC_SMALL_FAST_MODEL:-}" ]; then
+                local models
+                models=$(pick_copilot_models "http://$COPILOT_LOCALHOST_MAPPING:$COPILOT_PROXY_PORT")
+                local main_model="${models%% *}"
+                local fast_model="${models#* }"
+
+                [ -z "${ANTHROPIC_MODEL:-}" ] && DOCKER_ARGS+=("-e" "ANTHROPIC_MODEL=$main_model")
+                [ -z "${ANTHROPIC_SMALL_FAST_MODEL:-}" ] && DOCKER_ARGS+=("-e" "ANTHROPIC_SMALL_FAST_MODEL=$fast_model")
+            fi
+
+            # Configure proxy settings for container
+            local no_proxy="$COPILOT_HOST_MAPPING,$COPILOT_LOCALHOST_MAPPING,127.0.0.1"
+            DOCKER_ARGS+=("-e" "NO_PROXY=${NO_PROXY:+$NO_PROXY,}$no_proxy")
+            DOCKER_ARGS+=("-e" "no_grpc_proxy=${NO_GRPC_PROXY:+$NO_GRPC_PROXY,}$no_proxy")
+            ;;
+        oat)
+            # Claude OAuth token (experimental)
+            if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+                auth_error "CLAUDE_CODE_OAUTH_TOKEN not set for --auth-with oat" \
+                           "Set: export CLAUDE_CODE_OAUTH_TOKEN=your_token"
+            fi
+            DOCKER_ARGS+=("-e" "CLAUDE_CODE_OAUTH_TOKEN=$CLAUDE_CODE_OAUTH_TOKEN")
+            ;;
+        bedrock)
+            # AWS Bedrock
+            DOCKER_ARGS+=("-e" "CLAUDE_CODE_USE_BEDROCK=1")
+            if [ -d "$HOME/.aws" ]; then
+                DOCKER_ARGS+=("-v" "$HOME/.aws:/home/deva/.aws:ro")
+            fi
+            if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
+                DOCKER_ARGS+=("-e" "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID")
+            fi
+            if [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+                DOCKER_ARGS+=("-e" "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY")
+            fi
+            if [ -n "${AWS_SESSION_TOKEN:-}" ]; then
+                DOCKER_ARGS+=("-e" "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN")
+            fi
+            if [ -n "${AWS_REGION:-}" ]; then
+                DOCKER_ARGS+=("-e" "AWS_REGION=$AWS_REGION")
+            fi
+            ;;
+        vertex)
+            # Google Vertex AI
+            DOCKER_ARGS+=("-e" "CLAUDE_CODE_USE_VERTEX=1")
+            if [ -d "$HOME/.config/gcloud" ]; then
+                DOCKER_ARGS+=("-v" "$HOME/.config/gcloud:/home/deva/.config/gcloud:ro")
+            fi
+            if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+                DOCKER_ARGS+=("-v" "$GOOGLE_APPLICATION_CREDENTIALS:$GOOGLE_APPLICATION_CREDENTIALS:ro")
+                DOCKER_ARGS+=("-e" "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS")
+            fi
+            ;;
+        *)
+            auth_error "auth method '$method' not implemented"
+            ;;
+    esac
 }

--- a/agents/codex.sh
+++ b/agents/codex.sh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 
+# Load shared auth utilities
+# shellcheck disable=SC1091
+if [ -f "$(dirname "${BASH_SOURCE[0]}")/shared_auth.sh" ]; then
+    source "$(dirname "${BASH_SOURCE[0]}")/shared_auth.sh"
+fi
+
 agent_prepare() {
     local -a args
     if [ $# -gt 0 ]; then
@@ -9,26 +15,34 @@ agent_prepare() {
     fi
     AGENT_COMMAND=("codex")
 
+    # Parse auth method and filter remaining args using shared function
+    parse_auth_args "codex" "${args[@]+"${args[@]}"}"
+    local auth_method="$PARSED_AUTH_METHOD"
+    # Safe array assignment that works with set -u
+    local -a remaining_args=("${PARSED_REMAINING_ARGS[@]+"${PARSED_REMAINING_ARGS[@]}"}")
+
     local has_dangerous=false
     local has_model=false
 
-    for ((i=0; i<${#args[@]}; i++)); do
-        case "${args[$i]}" in
-            --dangerously-bypass-approvals-and-sandbox)
-                has_dangerous=true
-                ;;
-            -m|--model)
-                has_model=true
-                ((i++))
-                ;;
-            -m*)
-                has_model=true
-                ;;
-            --model=*)
-                has_model=true
-                ;;
-        esac
-    done
+    if [ ${#remaining_args[@]} -gt 0 ]; then
+        for ((i=0; i<${#remaining_args[@]}; i++)); do
+            case "${remaining_args[$i]}" in
+                --dangerously-bypass-approvals-and-sandbox)
+                    has_dangerous=true
+                    ;;
+                -m|--model)
+                    has_model=true
+                    ((i++))
+                    ;;
+                -m*)
+                    has_model=true
+                    ;;
+                --model=*)
+                    has_model=true
+                    ;;
+            esac
+        done
+    fi
 
     if [ "$has_dangerous" = false ]; then
         AGENT_COMMAND+=("--dangerously-bypass-approvals-and-sandbox")
@@ -37,9 +51,8 @@ agent_prepare() {
         AGENT_COMMAND+=("-m" "${DEVA_DEFAULT_CODEX_MODEL:-gpt-5-codex}")
     fi
 
-    if [ ${#args[@]} -gt 0 ]; then
-        AGENT_COMMAND+=("${args[@]}")
-    fi
+    # Safe array expansion for remaining args
+    AGENT_COMMAND+=("${remaining_args[@]+"${remaining_args[@]}"}")
 
     DOCKER_ARGS+=("-p" "127.0.0.1:1455:1455")
 
@@ -74,10 +87,22 @@ agent_prepare() {
         codex_home="$CONFIG_ROOT/codex/.codex"
     fi
 
+    # Strip conflicting env vars when OAuth auth.json exists
+    local has_oauth_file=false
     if [ -n "$codex_home" ] && [ -f "$codex_home/auth.json" ]; then
+        has_oauth_file=true
         strip_openai_env OPENAI_API_KEY
         strip_openai_env OPENAI_BASE_URL
         strip_openai_env OPENAI_ORGANIZATION
+    fi
+
+    # Setup authentication (after config mounting and stripping)
+    # Skip oauth setup if we have existing auth.json - it would conflict
+    if [ "$auth_method" = "chatgpt" ] && [ "$has_oauth_file" = true ]; then
+        # Use existing OAuth file, no additional setup needed
+        :
+    else
+        setup_codex_auth "$auth_method"
     fi
 }
 
@@ -100,4 +125,44 @@ strip_openai_env() {
         fi
     done
     DOCKER_ARGS=("${cleaned[@]}")
+}
+
+setup_codex_auth() {
+    local method="$1"
+
+    case "$method" in
+        chatgpt)
+            # Default ChatGPT OAuth - handled by existing mount logic
+            ;;
+        api-key)
+            validate_openai_key || auth_error "OPENAI_API_KEY not set for --auth-with api-key" \
+                                              "Set: export OPENAI_API_KEY=your_api_key"
+            DOCKER_ARGS+=("-e" "OPENAI_API_KEY=$OPENAI_API_KEY")
+            ;;
+        copilot)
+            validate_github_token || auth_error "No GitHub token found for copilot auth" \
+                                                "Run: copilot-api auth, or set GH_TOKEN=\$(gh auth token)"
+            start_copilot_proxy
+
+            DOCKER_ARGS+=("-e" "OPENAI_BASE_URL=http://$COPILOT_HOST_MAPPING:$COPILOT_PROXY_PORT")
+            DOCKER_ARGS+=("-e" "OPENAI_API_KEY=dummy")
+
+            # Auto-detect models if not already set
+            if [ -z "${OPENAI_MODEL:-}" ]; then
+                local models
+                models=$(pick_copilot_models "http://$COPILOT_LOCALHOST_MAPPING:$COPILOT_PROXY_PORT")
+                local main_model="${models%% *}"
+                # Use main model as default for Codex
+                DOCKER_ARGS+=("-e" "OPENAI_MODEL=$main_model")
+            fi
+
+            # Configure proxy settings for container
+            local no_proxy="$COPILOT_HOST_MAPPING,$COPILOT_LOCALHOST_MAPPING,127.0.0.1"
+            DOCKER_ARGS+=("-e" "NO_PROXY=${NO_PROXY:+$NO_PROXY,}$no_proxy")
+            DOCKER_ARGS+=("-e" "no_grpc_proxy=${NO_GRPC_PROXY:+$NO_GRPC_PROXY,}$no_proxy")
+            ;;
+        *)
+            auth_error "auth method '$method' not implemented"
+            ;;
+    esac
 }

--- a/agents/shared_auth.sh
+++ b/agents/shared_auth.sh
@@ -1,0 +1,286 @@
+# shellcheck shell=bash
+
+readonly COPILOT_DEFAULT_PORT="4141"
+readonly COPILOT_HOST_MAPPING="host.docker.internal"
+readonly COPILOT_LOCALHOST_MAPPING="localhost"
+readonly COPILOT_LOG_FILE="/tmp/deva-auth-copilot-api.log"
+readonly COPILOT_CACHE_TTL=300
+readonly COPILOT_CACHE_LOCK="/tmp/deva-auth-copilot-models.lock"
+
+COPILOT_MODELS_CACHE=""
+COPILOT_CACHE_TIME=0
+
+auth_error() {
+    echo "error: $1" >&2
+    [ -n "${2:-}" ] && echo "hint: $2" >&2
+    exit 1
+}
+
+debug_log() {
+    [ "${DEVA_DEBUG:-}" = "true" ] && echo "DEBUG: $*" >&2 || true
+}
+
+validate_port() {
+    local port="$1"
+    [[ "$port" =~ ^[0-9]+$ ]] && [ "$port" -ge 1024 ] && [ "$port" -le 65535 ]
+}
+
+validate_url() {
+    local url="$1"
+    [[ "$url" =~ ^https?://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$ ]]
+}
+
+validate_env_name() {
+    [[ "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]
+}
+
+validate_github_token() {
+    [ -f "$HOME/.local/share/copilot-api/github_token" ] || [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ]
+}
+
+validate_anthropic_key() {
+    [ -n "${ANTHROPIC_API_KEY:-}" ]
+}
+
+validate_openai_key() {
+    [ -n "${OPENAI_API_KEY:-}" ]
+}
+
+COPILOT_PROXY_PID=""
+COPILOT_PROXY_PORT="$COPILOT_DEFAULT_PORT"
+
+is_process_alive() {
+    local pid="$1"
+    [ -n "$pid" ] && [ -d "/proc/$pid" ] && grep -q "copilot-api" "/proc/$pid/cmdline" 2>/dev/null
+}
+
+start_copilot_proxy() {
+    if is_process_alive "$COPILOT_PROXY_PID"; then
+        echo "GitHub Copilot proxy already running (PID $COPILOT_PROXY_PID)"
+        return 0
+    fi
+
+    if curl -s -f "http://localhost:$COPILOT_PROXY_PORT/" >/dev/null 2>&1; then
+        echo "GitHub Copilot proxy already running on port $COPILOT_PROXY_PORT"
+        return 0
+    fi
+
+    validate_github_token || auth_error "No GitHub token found for copilot auth" \
+                                        "Run: copilot-api auth, or set GH_TOKEN=\$(gh auth token)"
+
+    local cmd=(copilot-api start --port "$COPILOT_PROXY_PORT")
+    if [ -f "$HOME/.local/share/copilot-api/github_token" ]; then
+        echo "Using saved GitHub token from copilot-api"
+    elif [ -n "${GH_TOKEN:-${GITHUB_TOKEN}}" ]; then
+        echo "Using provided GitHub token"
+        cmd+=(--github-token "${GH_TOKEN:-${GITHUB_TOKEN}}")
+    fi
+
+    debug_log "Starting GitHub Copilot API proxy on port $COPILOT_PROXY_PORT"
+    echo "Starting GitHub Copilot API proxy..."
+    echo "Proxy logs: $COPILOT_LOG_FILE"
+    "${cmd[@]}" >>"$COPILOT_LOG_FILE" 2>&1 &
+    COPILOT_PROXY_PID=$!
+
+    local timeout="${COPILOT_PROXY_TIMEOUT:-30}"
+    local attempt=0
+    local backoff=0.1
+    while [ "$attempt" -lt "$timeout" ]; do
+        if curl -s -f "http://localhost:$COPILOT_PROXY_PORT/" >/dev/null 2>&1; then
+            echo "✓ GitHub Copilot proxy ready on port $COPILOT_PROXY_PORT"
+            return 0
+        fi
+        sleep "$backoff"
+        attempt=$((attempt + 1))
+        [ "$backoff" = "0.1" ] && backoff=0.2 || [ "$backoff" = "0.2" ] && backoff=0.5 || [ "$backoff" = "0.5" ] && backoff=1
+    done
+
+    echo "Last 20 lines from proxy log:" >&2
+    tail -20 "$COPILOT_LOG_FILE" >&2
+    auth_error "Copilot proxy failed to start after ${timeout}s" \
+               "Check logs: $COPILOT_LOG_FILE"
+}
+
+stop_copilot_proxy() {
+    if [ -n "$COPILOT_PROXY_PID" ]; then
+        echo "Stopping Copilot proxy (PID $COPILOT_PROXY_PID)"
+        kill "$COPILOT_PROXY_PID" 2>/dev/null || true
+        COPILOT_PROXY_PID=""
+    fi
+}
+
+pick_best_model() {
+    local model_type="$1"
+    local available_models="$2"
+    local preferences=""
+
+    case "$model_type" in
+        main)
+            preferences="claude-opus-4.1:100 claude-opus-4:90 claude-sonnet-4:80 gpt-5:70 gpt-4o:60"
+            ;;
+        fast)
+            preferences="o3-mini-2025-01-31:100 o3-mini:90 gpt-4o-mini:80 gpt-5-mini:70 gpt-4o:60"
+            ;;
+        *)
+            debug_log "Unknown model type: $model_type"
+            return 1
+            ;;
+    esac
+
+    local best_model=""
+    local best_score=0
+
+    local pref
+    for pref in $preferences; do
+        local model="${pref%:*}"
+        local score="${pref#*:}"
+
+        if echo "$available_models" | grep -q "^$model$"; then
+            if [ "$score" -gt "$best_score" ]; then
+                best_model="$model"
+                best_score="$score"
+            fi
+        fi
+    done
+
+    echo "$best_model"
+}
+
+pick_copilot_models() {
+    local base_url="${1:-http://$COPILOT_LOCALHOST_MAPPING:$COPILOT_PROXY_PORT}"
+    local current_time
+    current_time=$(date +%s)
+
+    if [ -n "$COPILOT_MODELS_CACHE" ] && [ $((current_time - COPILOT_CACHE_TIME)) -lt $COPILOT_CACHE_TTL ]; then
+        debug_log "Using cached model selection: $COPILOT_MODELS_CACHE"
+        echo "$COPILOT_MODELS_CACHE"
+        return 0
+    fi
+
+    (
+        flock -x -w 5 200 || return 1
+
+        current_time=$(date +%s)
+        if [ -n "$COPILOT_MODELS_CACHE" ] && [ $((current_time - COPILOT_CACHE_TIME)) -lt $COPILOT_CACHE_TTL ]; then
+            debug_log "Using cached model selection: $COPILOT_MODELS_CACHE"
+            echo "$COPILOT_MODELS_CACHE"
+            return 0
+        fi
+
+        debug_log "Cache miss, fetching models from $base_url"
+        local models_json=""
+
+        if command -v curl >/dev/null 2>&1; then
+            models_json=$(curl -fsS --max-time 2 "$base_url/v1/models" 2>/dev/null || true)
+        fi
+
+        local main_model=""
+        local fast_model=""
+
+        if [ -n "$models_json" ] && command -v jq >/dev/null 2>&1; then
+            local all_models
+            all_models=$(echo "$models_json" | jq -r '.data[].id' 2>/dev/null || true)
+
+            if [ -n "$all_models" ]; then
+                debug_log "Available models: $(echo "$all_models" | tr '\n' ' ')"
+                main_model=$(pick_best_model "main" "$all_models")
+                fast_model=$(pick_best_model "fast" "$all_models")
+            fi
+        fi
+
+        main_model="${main_model:-claude-sonnet-4}"
+        fast_model="${fast_model:-o3-mini-2025-01-31}"
+
+        COPILOT_MODELS_CACHE="$main_model $fast_model"
+        COPILOT_CACHE_TIME="$current_time"
+
+        debug_log "Selected and cached models: main=$main_model fast=$fast_model"
+        echo "$main_model $fast_model"
+    ) 200>"$COPILOT_CACHE_LOCK"
+}
+
+convert_claude_model_alias() {
+    case "$1" in
+        sonnet-4) echo "claude-sonnet-4" ;;
+        opus-4) echo "claude-opus-4" ;;
+        opus-4.1) echo "claude-opus-4.1" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+convert_openai_model_alias() {
+    case "$1" in
+        gpt-5-codex) echo "gpt-5-codex" ;;
+        gpt-5) echo "gpt-5" ;;
+        4o) echo "gpt-4o" ;;
+        4o-mini) echo "gpt-4o-mini" ;;
+        o3-mini) echo "o3-mini" ;;
+        *) echo "$1" ;;
+    esac
+}
+
+parse_auth_args() {
+    local agent_name="$1"
+    shift
+    local -a args=("$@")
+    local -a supported_methods
+
+    case "$agent_name" in
+        claude)
+            supported_methods=(claude oat api-key bedrock vertex copilot)
+            ;;
+        codex)
+            supported_methods=(chatgpt api-key copilot)
+            ;;
+        *)
+            auth_error "Unknown agent: $agent_name"
+            ;;
+    esac
+
+    local auth_method=""
+    local -a remaining_args=()
+    local i=0
+
+    while [ $i -lt ${#args[@]} ]; do
+        case "${args[$i]}" in
+            --auth-with)
+                if [ $((i + 1)) -ge ${#args[@]} ]; then
+                    auth_error "--auth-with requires a method"
+                fi
+                auth_method="${args[$((i + 1))]}"
+
+                local method_supported=false
+                local method
+                for method in "${supported_methods[@]}"; do
+                    if [ "$method" = "$auth_method" ]; then
+                        method_supported=true
+                        break
+                    fi
+                done
+
+                if [ "$method_supported" = false ]; then
+                    local supported_list
+                    supported_list=$(IFS=', '; echo "${supported_methods[*]}")
+                    auth_error "$agent_name agent doesn't support auth method '$auth_method'" \
+                               "Supported: $supported_list"
+                fi
+
+                i=$((i + 2))
+                ;;
+            *)
+                remaining_args+=("${args[$i]}")
+                i=$((i + 1))
+                ;;
+        esac
+    done
+
+    if [ -z "$auth_method" ]; then
+        case "$agent_name" in
+            claude) auth_method="claude" ;;
+            codex) auth_method="chatgpt" ;;
+        esac
+    fi
+
+    PARSED_AUTH_METHOD="$auth_method"
+    PARSED_REMAINING_ARGS=("${remaining_args[@]+"${remaining_args[@]}"}")
+}

--- a/claude.sh
+++ b/claude.sh
@@ -158,13 +158,14 @@ pick_copilot_models() {
         done
 
         for m in \
-            "gpt-5-mini" \
+            "o3-mini-2025-01-31" \
+            "o3-mini" \
             "gpt-4o-mini" \
             "gpt-4o-mini-2024-07-18" \
             "o4-mini" \
             "o4-mini-2025-04-16" \
-            "o3-mini" \
             "o3-mini-paygo" \
+            "gpt-5-mini" \
             "grok-code-fast-1"
         do
             echo "$ids" | grep -qx "$m" && { fast="$m"; break; }
@@ -172,7 +173,7 @@ pick_copilot_models() {
     fi
 
     [ -z "$main" ] && main="claude-sonnet-4"
-    [ -z "$fast" ] && fast="gpt-4o-mini"
+    [ -z "$fast" ] && fast="o3-mini-2025-01-31"
     echo "$main $fast"
 }
 
@@ -966,7 +967,7 @@ run_claude_local() {
         local _main_set_by_user="${ANTHROPIC_MODEL:+1}"
         local _fast_set_by_user="${ANTHROPIC_SMALL_FAST_MODEL:+1}"
         ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-claude-sonnet-4}"
-        ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-gpt-4o-mini}"
+        ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-o3-mini-2025-01-31}"
         export ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL
 
         echo "GitHub Copilot proxy will start on port 4141"
@@ -1458,7 +1459,7 @@ case "$AUTH_MODE" in
         DOCKER_ARGS+=("-e" "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-claude-sonnet-4}")
     fi
     if ! user_specified_env "ANTHROPIC_SMALL_FAST_MODEL"; then
-        DOCKER_ARGS+=("-e" "ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-gpt-4o-mini}")
+        DOCKER_ARGS+=("-e" "ANTHROPIC_SMALL_FAST_MODEL=${ANTHROPIC_SMALL_FAST_MODEL:-o3-mini-2025-01-31}")
     fi
 
     if [ -d "$HOME/.local/share/copilot-api" ]; then

--- a/deva.sh
+++ b/deva.sh
@@ -4,16 +4,35 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AGENTS_DIR="$SCRIPT_DIR/agents"
 
+DEVA_DOCKER_IMAGE_ENV_SET=false
+if [ -n "${DEVA_DOCKER_IMAGE+x}" ]; then
+    DEVA_DOCKER_IMAGE_ENV_SET=true
+fi
+DEVA_DOCKER_TAG_ENV_SET=false
+if [ -n "${DEVA_DOCKER_TAG+x}" ]; then
+    DEVA_DOCKER_TAG_ENV_SET=true
+fi
+
 DEVA_DOCKER_IMAGE="${DEVA_DOCKER_IMAGE:-ghcr.io/thevibeworks/deva}"
 DEVA_DOCKER_TAG="${DEVA_DOCKER_TAG:-latest}"
 DEVA_CONTAINER_PREFIX="${DEVA_CONTAINER_PREFIX:-deva}"
 DEFAULT_AGENT="${DEVA_DEFAULT_AGENT:-claude}"
 
+# Profile controls
+# Prefer DEVA_PROFILE; accept legacy DEVA_IMAGE_PROFILE for back-compat
+PROFILE="${DEVA_PROFILE:-${DEVA_IMAGE_PROFILE:-}}"
+
+# Shared config directory (mounted for all agents, optional)
+CONFIG_ROOT=""
+
 USER_VOLUMES=()
 USER_ENVS=()
 EXTRA_DOCKER_ARGS=()
 CONFIG_HOME=""
+CONFIG_HOME_AUTO=false
 CONFIG_HOME_FROM_CLI=false
+AUTOLINK=true
+if [ -n "${DEVA_NO_AUTOLINK:-}" ]; then AUTOLINK=false; fi
 SKIP_CONFIG=false
 CONFIG_ERRORS=()
 LOADED_CONFIGS=()
@@ -25,7 +44,8 @@ usage() {
 deva.sh - Docker-based multi-agent launcher (Claude, Codex)
 
 Usage:
-  deva.sh [agent] [wrapper flags] [-- agent-flags]
+  deva.sh [deva flags] [agent] [-- agent-flags]
+  deva.sh [agent] [deva flags] [-- agent-flags]
   deva.sh shell
   deva.sh help
 
@@ -34,16 +54,19 @@ Container management:
   deva.sh --ps               List containers for current project
   deva.sh --show-config      Show resolved configuration (debug)
 
-Wrapper flags:
-  -v SRC:DEST[:OPT]     Mount additional volumes inside the container
-  -c DIR, --config-home DIR
-                        Mount an alternate auth/config home into /home/deva
-  -e VAR[=VALUE]        Pass environment variable into the container (pulls from host when VALUE omitted)
-  --host-net            Use host networking for the agent container
-  --                    Everything after this sentinel is passed to the agent unchanged
+Deva flags:
+  -v SRC:DEST[:OPT]       Mount additional volumes inside the container
+  -c DIR, --config-home   DIR
+                          Mount an alternate auth/config home into /home/deva
+  -e VAR[=VALUE]          Pass environment variable into the container (pulls from host when VALUE omitted)
+  -p NAME, --profile      NAME
+                          Select profile: base (default), rust. Pulls tag, falls back to Dockerfile.<profile>
+  --host-net              Use host networking for the agent container
+  --                      Everything after this sentinel is passed to the agent unchanged
 
 Examples:
   deva.sh                             # Launch default agent (Claude)
+  deva.sh -p rust claude              # Deva flags like `deva.sh --flags`
   deva.sh codex -v ~/.ssh:/home/deva/.ssh:ro -- -m gpt-5-codex
   deva.sh -c ~/work-claude-home -- --trace
   deva.sh --show-config               # Debug configuration
@@ -63,6 +86,21 @@ absolute_path() {
 import os, sys
 print(os.path.abspath(sys.argv[1]))
 PY
+}
+
+# Determine default per-agent config home under XDG
+default_config_home_for_agent() {
+    local agent="$1"
+    local xdg_home
+    xdg_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    printf '%s' "$xdg_home/deva/$agent"
+}
+
+validate_profile() {
+    case "$1" in
+    base | rust | "") return 0 ;;
+    *) return 1 ;;
+    esac
 }
 
 set_config_home_value() {
@@ -88,11 +126,43 @@ check_agent() {
 }
 
 check_image() {
-    if ! docker image inspect "${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" >/dev/null 2>&1; then
-        echo "Docker image ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG} not found locally" >&2
-        echo "Pull with: docker pull ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" >&2
-        exit 1
+    if docker image inspect "${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" >/dev/null 2>&1; then
+        return
     fi
+
+    # Try pulling first
+    if docker pull "${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" >/dev/null 2>&1; then
+        return
+    fi
+
+    # Determine matching local Dockerfile for suggestions (no auto-build)
+    local df=""
+    case "${PROFILE:-}" in
+    rust)
+        [ -f "${SCRIPT_DIR}/Dockerfile.rust" ] && df="${SCRIPT_DIR}/Dockerfile.rust" || df=""
+        ;;
+    esac
+
+    echo "Docker image ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG} not found locally" >&2
+    if [ -n "$df" ]; then
+        echo "A matching Dockerfile exists at: $df" >&2
+        case "${PROFILE:-}" in
+        rust)
+            echo "Build with: make build-rust" >&2
+            echo "or: docker build -f $df -t ghcr.io/thevibeworks/deva:rust \"$SCRIPT_DIR\"" >&2
+            ;;
+        "" | base)
+            echo "Build with: make build" >&2
+            echo "or: docker build -f Dockerfile -t ghcr.io/thevibeworks/deva:latest \"$SCRIPT_DIR\"" >&2
+            ;;
+        *)
+            echo "Build with your Dockerfile and tag appropriately (e.g., :${PROFILE})" >&2
+            ;;
+        esac
+    else
+        echo "Pull with: docker pull ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" >&2
+    fi
+    exit 1
 }
 
 dangerous_directory() {
@@ -118,7 +188,7 @@ WARNING: Running in a high-risk directory!
 Current directory: ${current_dir}
 
 deva.sh will grant full access to this directory and all subdirectories.
-Type 'yes' to continue: 
+Type 'yes' to continue:
 EOF
     read -r response
     if [ "$response" != "yes" ]; then
@@ -278,33 +348,33 @@ prepare_base_docker_args() {
         --add-host host.docker.internal:host-gateway
     )
 
-    if [ -n "${LANG:-}" ]; then DOCKER_ARGS+=( -e "LANG=$LANG" ); fi
-    if [ -n "${LC_ALL:-}" ]; then DOCKER_ARGS+=( -e "LC_ALL=$LC_ALL" ); fi
-    if [ -n "${TZ:-}" ]; then DOCKER_ARGS+=( -e "TZ=$TZ" ); fi
-    if [ -n "${GIT_AUTHOR_NAME:-}" ]; then DOCKER_ARGS+=( -e "GIT_AUTHOR_NAME=$GIT_AUTHOR_NAME" ); fi
-    if [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then DOCKER_ARGS+=( -e "GIT_AUTHOR_EMAIL=$GIT_AUTHOR_EMAIL" ); fi
-    if [ -n "${GIT_COMMITTER_NAME:-}" ]; then DOCKER_ARGS+=( -e "GIT_COMMITTER_NAME=$GIT_COMMITTER_NAME" ); fi
-    if [ -n "${GIT_COMMITTER_EMAIL:-}" ]; then DOCKER_ARGS+=( -e "GIT_COMMITTER_EMAIL=$GIT_COMMITTER_EMAIL" ); fi
-    if [ -n "${GH_TOKEN:-}" ]; then DOCKER_ARGS+=( -e "GH_TOKEN=$GH_TOKEN" ); fi
-    if [ -n "${GITHUB_TOKEN:-}" ]; then DOCKER_ARGS+=( -e "GITHUB_TOKEN=$GITHUB_TOKEN" ); fi
-    if [ -n "${OPENAI_API_KEY:-}" ]; then DOCKER_ARGS+=( -e "OPENAI_API_KEY=$OPENAI_API_KEY" ); fi
-    if [ -n "${OPENAI_ORGANIZATION:-}" ]; then DOCKER_ARGS+=( -e "OPENAI_ORGANIZATION=$OPENAI_ORGANIZATION" ); fi
-    if [ -n "${OPENAI_BASE_URL:-}" ]; then DOCKER_ARGS+=( -e "OPENAI_BASE_URL=$OPENAI_BASE_URL" ); fi
+    if [ -n "${LANG:-}" ]; then DOCKER_ARGS+=(-e "LANG=$LANG"); fi
+    if [ -n "${LC_ALL:-}" ]; then DOCKER_ARGS+=(-e "LC_ALL=$LC_ALL"); fi
+    if [ -n "${TZ:-}" ]; then DOCKER_ARGS+=(-e "TZ=$TZ"); fi
+    if [ -n "${GIT_AUTHOR_NAME:-}" ]; then DOCKER_ARGS+=(-e "GIT_AUTHOR_NAME=$GIT_AUTHOR_NAME"); fi
+    if [ -n "${GIT_AUTHOR_EMAIL:-}" ]; then DOCKER_ARGS+=(-e "GIT_AUTHOR_EMAIL=$GIT_AUTHOR_EMAIL"); fi
+    if [ -n "${GIT_COMMITTER_NAME:-}" ]; then DOCKER_ARGS+=(-e "GIT_COMMITTER_NAME=$GIT_COMMITTER_NAME"); fi
+    if [ -n "${GIT_COMMITTER_EMAIL:-}" ]; then DOCKER_ARGS+=(-e "GIT_COMMITTER_EMAIL=$GIT_COMMITTER_EMAIL"); fi
+    if [ -n "${GH_TOKEN:-}" ]; then DOCKER_ARGS+=(-e "GH_TOKEN=$GH_TOKEN"); fi
+    if [ -n "${GITHUB_TOKEN:-}" ]; then DOCKER_ARGS+=(-e "GITHUB_TOKEN=$GITHUB_TOKEN"); fi
+    if [ -n "${OPENAI_API_KEY:-}" ]; then DOCKER_ARGS+=(-e "OPENAI_API_KEY=$OPENAI_API_KEY"); fi
+    if [ -n "${OPENAI_ORGANIZATION:-}" ]; then DOCKER_ARGS+=(-e "OPENAI_ORGANIZATION=$OPENAI_ORGANIZATION"); fi
+    if [ -n "${OPENAI_BASE_URL:-}" ]; then DOCKER_ARGS+=(-e "OPENAI_BASE_URL=$OPENAI_BASE_URL"); fi
 
     if [ -n "${HTTP_PROXY:-}" ]; then
-        DOCKER_ARGS+=( -e "HTTP_PROXY=$(translate_localhost "$HTTP_PROXY")" )
+        DOCKER_ARGS+=(-e "HTTP_PROXY=$(translate_localhost "$HTTP_PROXY")")
     elif [ -n "${http_proxy:-}" ]; then
-        DOCKER_ARGS+=( -e "HTTP_PROXY=$(translate_localhost "$http_proxy")" )
+        DOCKER_ARGS+=(-e "HTTP_PROXY=$(translate_localhost "$http_proxy")")
     fi
     if [ -n "${HTTPS_PROXY:-}" ]; then
-        DOCKER_ARGS+=( -e "HTTPS_PROXY=$(translate_localhost "$HTTPS_PROXY")" )
+        DOCKER_ARGS+=(-e "HTTPS_PROXY=$(translate_localhost "$HTTPS_PROXY")")
     elif [ -n "${https_proxy:-}" ]; then
-        DOCKER_ARGS+=( -e "HTTPS_PROXY=$(translate_localhost "$https_proxy")" )
+        DOCKER_ARGS+=(-e "HTTPS_PROXY=$(translate_localhost "$https_proxy")")
     fi
     if [ -n "${NO_PROXY:-}" ]; then
-        DOCKER_ARGS+=( -e "NO_PROXY=$NO_PROXY" )
+        DOCKER_ARGS+=(-e "NO_PROXY=$NO_PROXY")
     elif [ -n "${no_proxy:-}" ]; then
-        DOCKER_ARGS+=( -e "NO_PROXY=$no_proxy" )
+        DOCKER_ARGS+=(-e "NO_PROXY=$no_proxy")
     fi
 }
 
@@ -325,7 +395,7 @@ append_user_volumes() {
             echo "" >&2
             warned=true
         fi
-        DOCKER_ARGS+=( -v "$mount" )
+        DOCKER_ARGS+=(-v "$mount")
     done
 }
 
@@ -336,7 +406,7 @@ append_user_envs() {
 
     local env_spec
     for env_spec in "${USER_ENVS[@]}"; do
-        DOCKER_ARGS+=( -e "$env_spec" )
+        DOCKER_ARGS+=(-e "$env_spec")
     done
 }
 
@@ -347,7 +417,7 @@ append_extra_docker_args() {
 
     local arg
     for arg in "${EXTRA_DOCKER_ARGS[@]}"; do
-        DOCKER_ARGS+=( "$arg" )
+        DOCKER_ARGS+=("$arg")
     done
 }
 
@@ -364,7 +434,22 @@ mount_config_home() {
         if [ "$name" = "." ] || [ "$name" = ".." ]; then
             continue
         fi
-        DOCKER_ARGS+=( -v "$item:/home/deva/$name" )
+        DOCKER_ARGS+=(-v "$item:/home/deva/$name")
+    done
+}
+
+mount_dir_contents_into_home() {
+    local base="$1"
+    [ -d "$base" ] || return
+    local item
+    for item in "$base"/.* "$base"/*; do
+        [ -e "$item" ] || continue
+        local name
+        name="$(basename "$item")"
+        if [ "$name" = "." ] || [ "$name" = ".." ]; then
+            continue
+        fi
+        DOCKER_ARGS+=(-v "$item:/home/deva/$name")
     done
 }
 
@@ -419,10 +504,10 @@ validate_config_value() {
     local value="$2"
 
     case "$value" in
-        *$'\x60'*)
-            echo "Security violation in $key=$value (backticks not allowed)"
-            return 1
-            ;;
+    *$'\x60'*)
+        echo "Security violation in $key=$value (backticks not allowed)"
+        return 1
+        ;;
     esac
 
     # shellcheck disable=SC2016
@@ -510,27 +595,38 @@ process_var_config() {
     value="$(expand_env_value "$value")"
 
     case "$name" in
-        CONFIG_HOME|CONFIG_DIR)
-            if [ "$CONFIG_HOME_FROM_CLI" = false ]; then
-                set_config_home_value "$value"
-            fi
-            ;;
-        DEFAULT_AGENT)
-            DEFAULT_AGENT="$value"
-            ;;
-        HOST_NET)
-            if [[ "$value" =~ ^(true|1|yes)$ ]]; then
-                EXTRA_DOCKER_ARGS+=("--net" "host")
-            fi
-            ;;
-        *)
-            if validate_env_name "$name"; then
-                export "$name"="$value"
-                USER_ENVS+=("$name=$value")
-            else
-                CONFIG_ERRORS+=("Unknown config variable: $name")
-            fi
-            ;;
+    CONFIG_HOME | CONFIG_DIR)
+        if [ "$CONFIG_HOME_FROM_CLI" = false ]; then
+            set_config_home_value "$value"
+        fi
+        ;;
+    DEFAULT_AGENT)
+        DEFAULT_AGENT="$value"
+        ;;
+    # New, preferred key
+    PROFILE)
+        PROFILE="$value"
+        ;;
+    # Legacy compatibility: map IMAGE_PROFILE to PROFILE silently
+    IMAGE_PROFILE)
+        PROFILE="$value"
+        ;;
+    AUTOLINK)
+        if [[ "$value" =~ ^(false|0|no)$ ]]; then AUTOLINK=false; else AUTOLINK=true; fi
+        ;;
+    HOST_NET)
+        if [[ "$value" =~ ^(true|1|yes)$ ]]; then
+            EXTRA_DOCKER_ARGS+=("--net" "host")
+        fi
+        ;;
+    *)
+        if validate_env_name "$name"; then
+            export "$name"="$value"
+            USER_ENVS+=("$name=$value")
+        else
+            CONFIG_ERRORS+=("Unknown config variable: $name")
+        fi
+        ;;
     esac
 }
 
@@ -558,7 +654,7 @@ load_config_file() {
     if [ ${#CONFIG_ERRORS[@]} -gt "$initial_errs" ]; then
         echo "ERROR: Config file $file has $((${#CONFIG_ERRORS[@]} - initial_errs)) issue(s)" >&2
         local idx
-        for ((idx=initial_errs; idx<${#CONFIG_ERRORS[@]}; idx++)); do
+        for ((idx = initial_errs; idx < ${#CONFIG_ERRORS[@]}; idx++)); do
             echo "  ${CONFIG_ERRORS[$idx]}" >&2
         done
         exit 1
@@ -608,83 +704,91 @@ parse_wrapper_args() {
         local arg
         arg="${incoming[$i]}"
         case "$arg" in
-            --)
-                for ((j=i+1; j<${#incoming[@]}; j++)); do
-                    remaining+=("${incoming[$j]}")
-                done
-                break
-                ;;
-            -v)
-                if [ $((i+1)) -ge ${#incoming[@]} ]; then
-                    echo "error: -v requires a mount specification" >&2
-                    exit 1
-                fi
-                USER_VOLUMES+=("$(normalize_volume_spec "${incoming[$((i+1))]}")")
-                i=$((i+2))
-                continue
-                ;;
-            -e)
-                if [ $((i+1)) -ge ${#incoming[@]} ]; then
-                    echo "error: -e requires a variable specification" >&2
-                    exit 1
-                fi
-                local env_spec
-                env_spec="${incoming[$((i+1))]}"
-                if [[ "$env_spec" == *"="* ]]; then
-                    USER_ENVS+=("$env_spec")
+        --)
+            for ((j = i + 1; j < ${#incoming[@]}; j++)); do
+                remaining+=("${incoming[$j]}")
+            done
+            break
+            ;;
+        -v)
+            if [ $((i + 1)) -ge ${#incoming[@]} ]; then
+                echo "error: -v requires a mount specification" >&2
+                exit 1
+            fi
+            USER_VOLUMES+=("$(normalize_volume_spec "${incoming[$((i + 1))]}")")
+            i=$((i + 2))
+            continue
+            ;;
+        -e)
+            if [ $((i + 1)) -ge ${#incoming[@]} ]; then
+                echo "error: -e requires a variable specification" >&2
+                exit 1
+            fi
+            local env_spec
+            env_spec="${incoming[$((i + 1))]}"
+            if [[ "$env_spec" == *"="* ]]; then
+                USER_ENVS+=("$env_spec")
+            else
+                if ! validate_env_name "$env_spec"; then
+                    echo "warning: invalid env name for -e: $env_spec" >&2
                 else
-                    if ! validate_env_name "$env_spec"; then
-                        echo "warning: invalid env name for -e: $env_spec" >&2
+                    local value="${!env_spec-}"
+                    if [ -n "$value" ]; then
+                        USER_ENVS+=("$env_spec=$value")
                     else
-                        local value="${!env_spec-}"
-                        if [ -n "$value" ]; then
-                            USER_ENVS+=("$env_spec=$value")
-                        else
-                            echo "warning: environment variable $env_spec not set; skipping" >&2
-                        fi
+                        echo "warning: environment variable $env_spec not set; skipping" >&2
                     fi
                 fi
-                i=$((i+2))
-                continue
-                ;;
-            --config-home)
-                if [ $((i+1)) -ge ${#incoming[@]} ]; then
-                    echo "error: --config-home requires a directory path" >&2
-                    exit 1
-                fi
-                local raw_dir
-                raw_dir="${incoming[$((i+1))]}"
-                set_config_home_value "$raw_dir"
-                CONFIG_HOME_FROM_CLI=true
-                i=$((i+2))
-                continue
-                ;;
-            -c)
-                if [ $((i+1)) -ge ${#incoming[@]} ]; then
-                    echo "error: -c requires a directory path" >&2
-                    exit 1
-                fi
-                local raw_c
-                raw_c="${incoming[$((i+1))]}"
-                set_config_home_value "$raw_c"
-                CONFIG_HOME_FROM_CLI=true
-                i=$((i+2))
-                continue
-                ;;
-            --no-config)
-                SKIP_CONFIG=true
-                i=$((i+1))
-                continue
-                ;;
-            --host-net)
-                EXTRA_DOCKER_ARGS+=("--net" "host")
-                i=$((i+1))
-                continue
-                ;;
-            *)
-                remaining+=("$arg")
-                i=$((i+1))
-                ;;
+            fi
+            i=$((i + 2))
+            continue
+            ;;
+        -c | --config-home)
+            if [ $((i + 1)) -ge ${#incoming[@]} ]; then
+                echo "error: --config-home requires a directory path" >&2
+                exit 1
+            fi
+            local raw_dir
+            raw_dir="${incoming[$((i + 1))]}"
+            set_config_home_value "$raw_dir"
+            CONFIG_HOME_FROM_CLI=true
+            i=$((i + 2))
+            continue
+            ;;
+        -p | --profile)
+            if [ $((i + 1)) -ge ${#incoming[@]} ]; then
+                echo "error: $arg requires a profile name" >&2
+                exit 1
+            fi
+            local prof="${incoming[$((i + 1))]}"
+            PROFILE="$prof"
+            if ! validate_profile "$prof"; then
+                echo "error: unknown profile '$prof'. Valid: base, rust." >&2
+                echo "hint: if you intended '-p' for the agent, place it after '--' (e.g., deva.sh claude -- -p 'task')" >&2
+                exit 1
+            fi
+            i=$((i + 2))
+            continue
+            ;;
+        --no-autolink)
+            AUTOLINK=false
+            i=$((i + 1))
+            continue
+            ;;
+        --no-config)
+            SKIP_CONFIG=true
+            i=$((i + 1))
+            continue
+            ;;
+        --host-net)
+            EXTRA_DOCKER_ARGS+=("--net" "host")
+            i=$((i + 1))
+            continue
+            ;;
+        *)
+            remaining+=("$arg")
+            i=$((i + 1))
+            ;;
         esac
     done
 
@@ -704,33 +808,94 @@ load_agent_module() {
     fi
 }
 
+# Resolve image based on selected profile and overrides
+resolve_profile() {
+    # Map profiles to images (prefer prebuilt registries, fallback handled by check_image)
+    local default_repo="ghcr.io/thevibeworks/deva"
+    case "${PROFILE:-}" in
+    "" | base)
+        if [ "$DEVA_DOCKER_IMAGE_ENV_SET" = false ]; then
+            DEVA_DOCKER_IMAGE="$default_repo"
+        fi
+        if [ "$DEVA_DOCKER_TAG_ENV_SET" = false ]; then
+            DEVA_DOCKER_TAG="latest"
+        fi
+        ;;
+    rust)
+        if [ "$DEVA_DOCKER_IMAGE_ENV_SET" = false ]; then
+            DEVA_DOCKER_IMAGE="$default_repo"
+        fi
+        if [ "$DEVA_DOCKER_TAG_ENV_SET" = false ]; then
+            DEVA_DOCKER_TAG="rust"
+        fi
+        ;;
+    *)
+        # Unknown profile – leave as provided by env, check_image will report
+        if [ "$DEVA_DOCKER_IMAGE_ENV_SET" = false ] && [ -z "${DEVA_DOCKER_IMAGE:-}" ]; then
+            DEVA_DOCKER_IMAGE="$default_repo"
+        fi
+        ;;
+    esac
+}
+
+is_known_agent() { [ -f "$AGENTS_DIR/$1.sh" ]; }
+
 ACTION="run"
 MANAGEMENT_MODE="launch"
 
-if [ $# -gt 0 ]; then
-    case "$1" in
-        help|--help|-h)
-            usage
-            exit 0
-            ;;
-        --show-config)
-            MANAGEMENT_MODE="show-config"
-            shift
-            ;;
-        shell)
-            MANAGEMENT_MODE="inspect"
-            ACTION="shell"
-            shift
-            ;;
-        --inspect)
-            MANAGEMENT_MODE="inspect"
-            shift
-            ;;
-        --ps)
-            MANAGEMENT_MODE="ps"
-            shift
-            ;;
+# Split CLI into Deva flags, agent, and agent args (after --)
+RAW_ARGS=("$@")
+WRAPPER_ARGS=()
+AGENT_ARGV=()
+ACTIVE_AGENT=""
+
+# Find sentinel index
+SENTINEL_IDX=-1
+if [ ${#RAW_ARGS[@]} -gt 0 ]; then
+for i in "${!RAW_ARGS[@]}"; do
+    if [ "${RAW_ARGS[$i]}" = "--" ]; then
+        SENTINEL_IDX=$i
+        break
+    fi
+done
+fi
+
+PRE_ARGS=()
+POST_ARGS=()
+if [ "$SENTINEL_IDX" -ge 0 ]; then
+    for ((i = 0; i < SENTINEL_IDX; i++)); do PRE_ARGS+=("${RAW_ARGS[$i]}"); done
+    for ((i = SENTINEL_IDX + 1; i < ${#RAW_ARGS[@]}; i++)); do POST_ARGS+=("${RAW_ARGS[$i]}"); done
+else
+    if [ ${#RAW_ARGS[@]} -gt 0 ]; then
+        PRE_ARGS=("${RAW_ARGS[@]}")
+    else
+        PRE_ARGS=()
+    fi
+fi
+
+# Detect management commands in PRE_ARGS
+if [ ${#PRE_ARGS[@]} -gt 0 ]; then
+for tok in "${PRE_ARGS[@]}"; do
+    case "$tok" in
+    help | --help | -h)
+        usage
+        exit 0
+        ;;
+    --show-config)
+        MANAGEMENT_MODE="show-config"
+        ;;
+    shell)
+        MANAGEMENT_MODE="inspect"
+        ACTION="shell"
+        ;;
+    --inspect)
+        MANAGEMENT_MODE="inspect"
+        ;;
+    --ps)
+        MANAGEMENT_MODE="ps"
+        ;;
     esac
+done
 fi
 
 if [ "$MANAGEMENT_MODE" = "inspect" ] || [ "$MANAGEMENT_MODE" = "ps" ] || [ "$MANAGEMENT_MODE" = "show-config" ]; then
@@ -741,13 +906,20 @@ if [ "$MANAGEMENT_MODE" = "inspect" ] || [ "$MANAGEMENT_MODE" = "ps" ] || [ "$MA
 
     if [ "$MANAGEMENT_MODE" = "show-config" ]; then
         # Parse args first to load config
-        if [ $# -gt 0 ]; then
-            parse_wrapper_args "$@"
+        if [ ${#RAW_ARGS[@]} -gt 0 ]; then
+            parse_wrapper_args "${RAW_ARGS[@]}"
         fi
         load_config_sources
-        if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
-            ACTIVE_AGENT="$1"
-        else
+        # Detect agent from PRE_ARGS
+        if [ ${#PRE_ARGS[@]} -gt 0 ]; then
+            for tok in "${PRE_ARGS[@]}"; do
+                if [[ "$tok" != -* ]] && [[ "$tok" != "help" ]] && [[ "$tok" != "shell" ]] && [[ "$tok" != "--inspect" ]] && [[ "$tok" != "--ps" ]] && [[ "$tok" != "--show-config" ]] && is_known_agent "$tok"; then
+                    ACTIVE_AGENT="$tok"
+                    break
+                fi
+            done
+        fi
+        if [ -z "$ACTIVE_AGENT" ]; then
             ACTIVE_AGENT="$DEFAULT_AGENT"
         fi
         show_config
@@ -759,34 +931,53 @@ if [ "$MANAGEMENT_MODE" = "inspect" ] || [ "$MANAGEMENT_MODE" = "ps" ] || [ "$MA
     exit 0
 fi
 
-if [ $# -gt 0 ] && [ "$1" = "run" ]; then
-    shift
+# Select agent: first token in PRE_ARGS that matches a known agent
+agent_idx=-1
+if [ ${#PRE_ARGS[@]} -gt 0 ]; then
+for i in "${!PRE_ARGS[@]}"; do
+    tok="${PRE_ARGS[$i]}"
+    if [[ "$tok" != -* ]] && is_known_agent "$tok"; then
+        ACTIVE_AGENT="$tok"
+        agent_idx=$i
+        AGENT_EXPLICIT=true
+        break
+    fi
+done
 fi
 
-# Agent selection: First non-flag argument is the agent name.
-# If no agent specified, DEFAULT_AGENT is used (typically "claude").
-# Examples:
-#   deva.sh           → uses DEFAULT_AGENT (claude)
-#   deva.sh codex     → uses codex agent
-#   deva.sh -v /foo   → uses DEFAULT_AGENT with volume mount
-if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
-    ACTIVE_AGENT="$1"
-    shift
-    AGENT_EXPLICIT=true
-else
+if [ -z "$ACTIVE_AGENT" ]; then
     ACTIVE_AGENT="$DEFAULT_AGENT"
+    AGENT_EXPLICIT=false
 fi
 
-if [ $# -gt 0 ]; then
-    AGENT_ARGS=("$@")
+# Build WRAPPER_ARGS = PRE_ARGS minus agent token
+if [ ${#PRE_ARGS[@]} -gt 0 ]; then
+for i in "${!PRE_ARGS[@]}"; do
+    if [ "$i" -eq "$agent_idx" ]; then continue; fi
+    WRAPPER_ARGS+=("${PRE_ARGS[$i]}")
+done
+fi
+
+# Agent argv is everything after --
+if [ ${#POST_ARGS[@]} -gt 0 ]; then
+    AGENT_ARGV=("${POST_ARGS[@]}")
 else
-    AGENT_ARGS=()
+    AGENT_ARGV=()
 fi
 
-if [ ${#AGENT_ARGS[@]} -gt 0 ]; then
-    parse_wrapper_args "${AGENT_ARGS[@]}"
+# Parse Deva flags
+if [ ${#WRAPPER_ARGS[@]} -gt 0 ]; then
+    parse_wrapper_args "${WRAPPER_ARGS[@]}"
 else
     parse_wrapper_args
+fi
+# Back-compat: treat unrecognized wrapper tokens as agent args
+if [ ${#AGENT_ARGS[@]} -gt 0 ]; then
+    if [ ${#AGENT_ARGV[@]} -gt 0 ]; then
+        AGENT_ARGV=("${AGENT_ARGS[@]}" "${AGENT_ARGV[@]}")
+    else
+        AGENT_ARGV=("${AGENT_ARGS[@]}")
+    fi
 fi
 
 load_config_sources
@@ -795,6 +986,65 @@ if [ "$AGENT_EXPLICIT" = false ]; then
     ACTIVE_AGENT="$DEFAULT_AGENT"
 fi
 
+# Default per-agent CONFIG_HOME if not set
+if [ -z "$CONFIG_HOME" ]; then
+    set_config_home_value "$(default_config_home_for_agent "$ACTIVE_AGENT")"
+    CONFIG_HOME_AUTO=true
+fi
+
+# Discover CONFIG_ROOT when using default XDG per-agent home
+if [ "$CONFIG_HOME_AUTO" = true ]; then
+    CONFIG_ROOT="$(dirname "$CONFIG_HOME")"
+fi
+
+# If user passed -c (or legacy -H) pointing at a deva root, treat it as CONFIG_ROOT
+if [ "$CONFIG_HOME_FROM_CLI" = true ] && [ -n "$CONFIG_HOME" ]; then
+    if [ -d "$CONFIG_HOME/claude" ] || [ -d "$CONFIG_HOME/codex" ]; then
+        CONFIG_ROOT="$CONFIG_HOME"
+        CONFIG_HOME=""
+        CONFIG_HOME_AUTO=false
+    fi
+fi
+
+# Auto-link legacy creds into deva root if absent (optional)
+autolink_legacy_into_deva_root() {
+    [ "$AUTOLINK" = true ] || return
+    [ "$CONFIG_HOME_FROM_CLI" = false ] || return
+    [ -n "${CONFIG_ROOT:-}" ] || return
+    [ -d "$CONFIG_ROOT" ] || mkdir -p "$CONFIG_ROOT"
+
+    # Claude
+    if [ -d "$HOME/.claude" ] || [ -f "$HOME/.claude.json" ]; then
+        [ -d "$CONFIG_ROOT/claude" ] || mkdir -p "$CONFIG_ROOT/claude"
+        if [ -d "$HOME/.claude" ] && [ ! -e "$CONFIG_ROOT/claude/.claude" ] && [ ! -L "$CONFIG_ROOT/claude/.claude" ]; then
+            ln -s "$HOME/.claude" "$CONFIG_ROOT/claude/.claude"
+            echo "autolink: ~/.claude -> $CONFIG_ROOT/claude/.claude" >&2
+        fi
+        if [ -f "$HOME/.claude.json" ] && [ ! -e "$CONFIG_ROOT/claude/.claude.json" ] && [ ! -L "$CONFIG_ROOT/claude/.claude.json" ]; then
+            ln -s "$HOME/.claude.json" "$CONFIG_ROOT/claude/.claude.json"
+            echo "autolink: ~/.claude.json -> $CONFIG_ROOT/claude/.claude.json" >&2
+        fi
+    fi
+    # Ensure a persistent file exists for Claude CLI settings
+    if [ -d "$CONFIG_ROOT/claude" ] && [ ! -e "$CONFIG_ROOT/claude/.claude.json" ] && [ ! -L "$CONFIG_ROOT/claude/.claude.json" ]; then
+        echo '{}' >"$CONFIG_ROOT/claude/.claude.json"
+        echo "scaffold: created $CONFIG_ROOT/claude/.claude.json" >&2
+    fi
+
+    # Codex
+    if [ -d "$HOME/.codex" ]; then
+        [ -d "$CONFIG_ROOT/codex" ] || mkdir -p "$CONFIG_ROOT/codex"
+        if [ ! -e "$CONFIG_ROOT/codex/.codex" ] && [ ! -L "$CONFIG_ROOT/codex/.codex" ]; then
+            ln -s "$HOME/.codex" "$CONFIG_ROOT/codex/.codex"
+            echo "autolink: ~/.codex -> $CONFIG_ROOT/codex/.codex" >&2
+        fi
+    fi
+    # Ensure Codex dir exists for persistence
+    if [ -d "$CONFIG_ROOT" ]; then
+        [ -d "$CONFIG_ROOT/codex/.codex" ] || mkdir -p "$CONFIG_ROOT/codex/.codex"
+    fi
+}
+
 check_agent "$ACTIVE_AGENT"
 
 if [ -n "$CONFIG_HOME" ]; then
@@ -802,7 +1052,7 @@ if [ -n "$CONFIG_HOME" ]; then
         mkdir -p "$CONFIG_HOME"
     fi
     if [ "$ACTIVE_AGENT" = "claude" ] && [ ! -f "$CONFIG_HOME/.claude.json" ]; then
-        echo '{}' > "$CONFIG_HOME/.claude.json"
+        echo '{}' >"$CONFIG_HOME/.claude.json"
     fi
 fi
 
@@ -810,21 +1060,33 @@ if dangerous_directory; then
     warn_dangerous_directory
 fi
 
+resolve_profile
 check_image
 prepare_base_docker_args
 append_user_volumes
 append_user_envs
 append_extra_docker_args
-mount_config_home
+# Mount configs: prefer full deva root if detected
+if [ -n "$CONFIG_ROOT" ] && [ -d "$CONFIG_ROOT" ]; then
+    autolink_legacy_into_deva_root
+    for d in "$CONFIG_ROOT"/*; do
+        [ -d "$d" ] || continue
+        [ "$(basename "$d")" = "_shared" ] && continue
+        mount_dir_contents_into_home "$d"
+    done
+else
+    autolink_legacy_into_deva_root
+    mount_config_home
+fi
 load_agent_module
 AGENT_COMMAND=()
-if [ ${#AGENT_ARGS[@]} -gt 0 ]; then
-    agent_prepare "${AGENT_ARGS[@]}"
+if [ ${#AGENT_ARGV[@]} -gt 0 ]; then
+    agent_prepare "${AGENT_ARGV[@]}"
 else
     agent_prepare
 fi
 
-DOCKER_ARGS+=( "${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" )
+DOCKER_ARGS+=("${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}")
 
 if [ "$ACTION" = "shell" ]; then
     AGENT_COMMAND=("/bin/zsh")
@@ -835,5 +1097,5 @@ if [ ${#AGENT_COMMAND[@]} -eq 0 ]; then
     exit 1
 fi
 
-echo "Launching ${ACTIVE_AGENT} via ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}" 
+echo "Launching ${ACTIVE_AGENT} via ${DEVA_DOCKER_IMAGE}:${DEVA_DOCKER_TAG}"
 docker "${DOCKER_ARGS[@]}" "${AGENT_COMMAND[@]}"


### PR DESCRIPTION
## Summary

Major enhancement adding profile-based image selection, XDG config home support, and unified multi-auth system across agents.

## Changes

### Profile System (`-p`/`--profile`)
- Add `--profile` flag for image selection (base, rust)
- Flags work before or after agent name for flexibility
- Pull missing images automatically with build hints
- Add `Dockerfile.rust` with full Rust toolchain
- New Makefile targets: `build-rust`, `buildx-multi-rust`, `build-all`

### XDG Config Root
- Default: `~/.config/deva/{claude,codex}` per-agent homes
- `-c DIR` detects DEVA ROOT (contains `claude/` or `codex/`)
- Auto-link legacy `~/.claude*`, `~/.codex` on first run
- `--no-autolink` to disable automatic symlinking

### Multi-Auth System
- New `agents/shared_auth.sh` with reusable utilities
- **Claude**: claude/oat/api-key/bedrock/vertex/copilot
- **Codex**: chatgpt/api-key/copilot
- Copilot proxy with auto-model detection
- Agent-level auth: `deva.sh claude --auth-with bedrock`
- Model selection caching with 300s TTL

### Improvements
- Strip conflicting `OPENAI_*` env vars when Codex OAuth active
- Fix Rust installer ownership in `Dockerfile.rust`
- Update CLI versions: Claude 1.0.119, Codex 0.39.0
- Default fast model: o3-mini-2025-01-31

## Breaking Changes

- `-p` reserved for deva profiles; pass agent prompts after `--`:
  - Before: `deva.sh claude -p "task"`
  - After: `deva.sh claude -- -p "task"`
- `-H` replaced by `-c`/`--config-home`
- Profiles map to image tags (not Dockerfiles)

## Test Plan

- [x] Shellcheck passes (false positives for sourced vars)
- [x] Profile switching works: base, rust
- [x] XDG config root detection and mounting
- [x] Auto-linking creates symlinks correctly
- [x] Multi-auth methods work per agent
- [x] Copilot proxy lifecycle management
- [ ] Integration test: claude with bedrock
- [ ] Integration test: codex with copilot
- [ ] Build rust image and verify toolchain

## Migration Guide

```bash
# Update CLI usage with -- for agent flags
deva.sh claude -- -p "implement feature"

# Migrate to XDG (optional)
mkdir -p ~/.config/deva/{claude,codex}
mv ~/.claude ~/.config/deva/claude/.claude
mv ~/.claude.json ~/.config/deva/claude/.claude.json
mv ~/.codex ~/.config/deva/codex/.codex

# Or let auto-link handle it automatically
deva.sh claude  # creates symlinks on first run
```

## Related

Part of ongoing multi-agent enhancement. Future work:
- Persistent container reuse (#108)
- Additional profiles (go, python, etc.)